### PR TITLE
tests and logic to handle events with periods in their names

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -23,6 +23,12 @@ exports.track = function(msg, settings){
     eventName = appEvents[eventName];
   }
 
+  // Facebook App Events will error if there's a period in the event name
+  // so we replace all periods with underscores
+  if (eventName.indexOf('.') !== -1) {
+    eventName = eventName.split('.').join('_');
+  }
+
   return reject(extend(
     addContext(msg, settings),
     customParams(msg, eventName)

--- a/test/fixtures/track-custom-period.json
+++ b/test/fixtures/track-custom-period.json
@@ -1,0 +1,48 @@
+{
+  "input": {
+    "type": "track",
+    "event": "Friend.Added",
+    "userId": "user-id",
+    "properties": {
+      "level": 10
+    },
+    "timestamp": "2015-11-09",
+    "context": {
+      "ip": "10.0.0.2",
+      "app": {
+        "namespace": "com.segment.TestApp"
+      },
+      "device": {
+        "manufacturer": "some-brand",
+        "type": "ios",
+        "advertisingId": "159358"
+      },
+      "network": {
+        "carrier": "some-carrier"
+      },
+      "locale": "en-US",
+      "library": {
+        "name": "analytics-ios"
+      },
+      "referrer": {
+        "type": "iad",
+        "id": "some-id"
+      }
+    }
+  },
+  "output": {
+    "event": "CUSTOM_APP_EVENTS",
+    "advertiser_id": "159358",
+    "advertiser_tracking_enabled": 1,
+    "application_tracking_enabled": 1,
+    "bundle_id": "com.segment.TestApp",
+    "custom_events": [
+      {
+        "_eventName": "Friend_Added",
+        "_logTime": 1447027200,
+        "fb_currency": "USD",
+        "level": 10
+      }
+    ]
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -82,6 +82,12 @@ describe('Facebook App Events', function(){
       });
     });
 
+    describe('custom track with a period in the name', function(){
+      it('should map custom track with a period in the name', function(){
+        test.maps('track-custom-period');
+      });
+    });
+
     describe('Application Installed', function() {
       it('should map Application Installed', function(){
         test.maps('track-app-install');
@@ -151,6 +157,15 @@ describe('Facebook App Events', function(){
 
     it('should track custom correctly', function(done){
       var json = test.fixture('track-custom-mapped');
+      test
+        .track(json.input)
+        .sends(json.output)
+        .expects(200)
+        .end(done);
+    });
+
+    it('should track custom events with a period correctly', function(done){
+      var json = test.fixture('track-custom-period');
       test
         .track(json.input)
         .sends(json.output)


### PR DESCRIPTION
Facebook app events will error if there's a period in the event name so we replace all periods with underscores to get around this and for consistency with fb's event syntax.

@jgershen @sperand-io @myclamm 
