### PR TITLE
Update/custom events logic

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -23,6 +23,12 @@ exports.track = function(msg, settings){
     eventName = appEvents[eventName];
   }
 
+  // Facebook App Events will error if there's a period in the event name
+  // so we replace all periods with underscores
+  if (eventName.indexOf('.') !== -1) {
+    eventName = eventName.split('.').join('_');
+  }
+
   return reject(extend(
     addContext(msg, settings),
     customParams(msg, eventName)

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -29,6 +29,12 @@ exports.track = function(msg, settings){
     eventName = eventName.split('.').join('_');
   }
 
+  // Facebook App Events cannot receive events with names >= 40 characters
+  // so we truncate
+  if (eventName.length > 40) {
+    eventName = eventName.substring(0, 40);
+  }
+
   return reject(extend(
     addContext(msg, settings),
     customParams(msg, eventName)
@@ -204,7 +210,7 @@ function addContext(msg, settings){
   };
 
   if (app.namespace) context.bundle_id = app.namespace;
-  if (app.version) context.build_version = app.version;
+  if (app.version) context.bundle_short_version = app.version;
 
   return context;
 };

--- a/test/fixtures/track-app-opened.json
+++ b/test/fixtures/track-app-opened.json
@@ -7,7 +7,7 @@
     "timestamp": "2015-11-09",
     "context": {
       "ip": "10.0.0.2",
-      "app": { "namespace": "com.segment.TestApp" },
+      "app": { "namespace": "com.segment.TestApp", "version": 2 },
       "device": {
         "manufacturer": "some-brand",
         "type": "ios",
@@ -30,6 +30,7 @@
     "advertiser_tracking_enabled": 1,
     "application_tracking_enabled": 1,
     "bundle_id": "com.segment.TestApp",
+    "bundle_short_version": 2,
     "custom_events": [{
       "_eventName": "fb_mobile_activate_app",
       "_logTime": 1447027200,

--- a/test/fixtures/track-basic.json
+++ b/test/fixtures/track-basic.json
@@ -1,13 +1,13 @@
 {
   "input": {
     "type": "track",
-    "event": "Sang a Song",
+    "event": "Password Changed",
     "userId": "user-id",
     "properties": {},
     "timestamp": "2015-11-09",
     "context": {
       "ip": "10.0.0.2",
-      "app": { "namespace": "com.segment.TestApp" },
+      "app": { "namespace": "com.segment.TestApp", "version": 2 },
       "device": {
         "manufacturer": "some-brand",
         "type": "ios",
@@ -30,8 +30,9 @@
     "advertiser_tracking_enabled": 1,
     "application_tracking_enabled": 1,
     "bundle_id": "com.segment.TestApp",
+    "bundle_short_version": 2,
     "custom_events": [{
-          "_eventName": "Sang a Song",
+          "_eventName": "Password Changed",
           "_logTime": 1447027200,
           "fb_currency": "USD"
       }]

--- a/test/fixtures/track-custom-period.json
+++ b/test/fixtures/track-custom-period.json
@@ -1,0 +1,48 @@
+{
+  "input": {
+    "type": "track",
+    "event": "Friend.Added",
+    "userId": "user-id",
+    "properties": {
+      "level": 10
+    },
+    "timestamp": "2015-11-09",
+    "context": {
+      "ip": "10.0.0.2",
+      "app": {
+        "namespace": "com.segment.TestApp"
+      },
+      "device": {
+        "manufacturer": "some-brand",
+        "type": "ios",
+        "advertisingId": "159358"
+      },
+      "network": {
+        "carrier": "some-carrier"
+      },
+      "locale": "en-US",
+      "library": {
+        "name": "analytics-ios"
+      },
+      "referrer": {
+        "type": "iad",
+        "id": "some-id"
+      }
+    }
+  },
+  "output": {
+    "event": "CUSTOM_APP_EVENTS",
+    "advertiser_id": "159358",
+    "advertiser_tracking_enabled": 1,
+    "application_tracking_enabled": 1,
+    "bundle_id": "com.segment.TestApp",
+    "custom_events": [
+      {
+        "_eventName": "Friend_Added",
+        "_logTime": 1447027200,
+        "fb_currency": "USD",
+        "level": 10
+      }
+    ]
+  }
+}

--- a/test/fixtures/track-ecommerce-wishlisted-product.json
+++ b/test/fixtures/track-ecommerce-wishlisted-product.json
@@ -14,7 +14,7 @@
     },
     "context": {
       "ip": "10.0.0.2",
-      "app": { "namespace": "com.segment.TestApp" },
+      "app": { "namespace": "com.segment.TestApp", "version": 2.0 },
       "device": {
         "manufacturer": "some-brand",
         "type": "ios",
@@ -37,6 +37,7 @@
     "advertiser_tracking_enabled": 1,
     "application_tracking_enabled": 1,
     "bundle_id": "com.segment.TestApp",
+    "bundle_short_version": 2.0,
     "custom_events": [{
           "fb_content_id": "507f1f77bcf86cd799439011",
           "fb_description": "Monopoly: 3rd Edition",

--- a/test/fixtures/track-long-names.json
+++ b/test/fixtures/track-long-names.json
@@ -1,18 +1,24 @@
 {
   "input": {
     "type": "track",
-    "event": "Application Installed",
+    "event": "Testing in case someone sends us events with names longer than 40 characters",
     "userId": "user-id",
     "properties": {},
+    "timestamp": "2015-11-09",
     "context": {
       "ip": "10.0.0.2",
-      "app": { "namespace": "com.segment.TestApp", "version": 2 },
+      "app": {
+        "namespace": "com.segment.TestApp",
+        "version": 2
+      },
       "device": {
         "manufacturer": "some-brand",
         "type": "ios",
         "advertisingId": "159358"
       },
-      "network": { "carrier": "some-carrier" },
+      "network": {
+        "carrier": "some-carrier"
+      },
       "locale": "en-US",
       "library": {
         "name": "analytics-ios"
@@ -24,11 +30,18 @@
     }
   },
   "output": {
-    "event": "MOBILE_APP_INSTALL",
+    "event": "CUSTOM_APP_EVENTS",
     "advertiser_id": "159358",
     "advertiser_tracking_enabled": 1,
     "application_tracking_enabled": 1,
     "bundle_id": "com.segment.TestApp",
-    "bundle_short_version": 2
+    "bundle_short_version": 2,
+    "custom_events": [
+      {
+        "_eventName": "Testing in case someone sends us events ",
+        "_logTime": 1447027200,
+        "fb_currency": "USD"
+      }
+    ]
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -88,6 +88,12 @@ describe('Facebook App Events', function(){
       });
     });
 
+    describe('events with long names', function(){
+      it('should correctly truncate event names >= 40 characters', function(){
+        test.maps('track-long-names');
+      });
+    });
+
     describe('Application Installed', function() {
       it('should map Application Installed', function(){
         test.maps('track-app-install');
@@ -157,6 +163,15 @@ describe('Facebook App Events', function(){
 
     it('should track custom correctly', function(done){
       var json = test.fixture('track-custom-mapped');
+      test
+        .track(json.input)
+        .sends(json.output)
+        .expects(200)
+        .end(done);
+    });
+
+    it('should track long named events correctly', function(done){
+      var json = test.fixture('track-long-names');
       test
         .track(json.input)
         .sends(json.output)

--- a/test/index.js
+++ b/test/index.js
@@ -82,6 +82,12 @@ describe('Facebook App Events', function(){
       });
     });
 
+    describe('custom track with a period in the name', function(){
+      it('should map custom track with a period in the name', function(){
+        test.maps('track-custom-period');
+      });
+    });
+
     describe('Application Installed', function() {
       it('should map Application Installed', function(){
         test.maps('track-app-install');
@@ -151,6 +157,15 @@ describe('Facebook App Events', function(){
 
     it('should track custom correctly', function(done){
       var json = test.fixture('track-custom-mapped');
+      test
+        .track(json.input)
+        .sends(json.output)
+        .expects(200)
+        .end(done);
+    });
+
+    it('should track custom events with a period correctly', function(done){
+      var json = test.fixture('track-custom-period');
       test
         .track(json.input)
         .sends(json.output)


### PR DESCRIPTION
This PR updates custom event logic to comply with constraints of the Facebook API. Custom event names can only contain alphanumeric characters and _'s and event names cannot be longer than 40 characters. For this reason, we replace .'s with _'s to match the facebook event naming and truncate event names >40 characters.
