### PR TITLE
Custom Events retain name when unmapped, and app version is passed successfully.

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -19,7 +19,7 @@ var time = require('unix-time');
 exports.track = function(msg, settings){
   var eventName = msg.event();
   var appEvents = settings.appEvents;
-  if (appEvents && appEvents[eventName]) {
+  if (appEvents && appEvents[eventName] && (appEvents[eventName]!=="null") ) {
     eventName = appEvents[eventName];
   }
 

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -273,7 +273,6 @@ function numberOfItems(msg) {
     var quantities = extractValue(products, 'quantity');
     return foldl(function(quantity, value) {
       return quantity + value;
-      return quantity;
     }, 0, quantities);
   } 
 }

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -235,12 +235,12 @@ function customParams(msg, eventName){
   var customEvents = {
       _eventName: eventName,
       _logTime: time(msg.timestamp()),
-      _appVersion: msg.obj.context.app.version,
       fb_search_string: msg.proxy('properties.query'),
       fb_num_items: numberOfItems(msg),
       fb_content_id: contentIds(msg)
   };
-
+  // per FB docs, _appVersion is required in order to populate app version in event dashboard
+  if(msg.obj.context.app.version) customEvents._appVersion = msg.obj.context.app.version;
   delete properties.query;
   delete properties.quantity;
   delete properties.products;

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -235,6 +235,7 @@ function customParams(msg, eventName){
   var customEvents = {
       _eventName: eventName,
       _logTime: time(msg.timestamp()),
+      _appVersion: msg.obj.context.app.version,
       fb_search_string: msg.proxy('properties.query'),
       fb_num_items: numberOfItems(msg),
       fb_content_id: contentIds(msg)

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -233,14 +233,13 @@ function customParams(msg, eventName){
   };
   var properties = msg.properties(renames);
   var customEvents = {
+      _appVersion: msg.proxy('context.app.version'),
       _eventName: eventName,
       _logTime: time(msg.timestamp()),
       fb_search_string: msg.proxy('properties.query'),
       fb_num_items: numberOfItems(msg),
       fb_content_id: contentIds(msg)
   };
-  // per FB docs, _appVersion is required in order to populate app version in event dashboard
-  if(msg.obj.context.app.version) customEvents._appVersion = msg.obj.context.app.version;
   delete properties.query;
   delete properties.quantity;
   delete properties.products;

--- a/test/fixtures/track-app-opened.json
+++ b/test/fixtures/track-app-opened.json
@@ -34,6 +34,7 @@
     "custom_events": [{
       "_eventName": "fb_mobile_activate_app",
       "_logTime": 1447027200,
+      "_appVersion": 2,
       "fb_currency": "USD"
     }]
   }

--- a/test/fixtures/track-custom-mapped.json
+++ b/test/fixtures/track-custom-mapped.json
@@ -7,7 +7,7 @@
     "timestamp": "2015-11-09",
     "context": {
       "ip": "10.0.0.2",
-      "app": { "namespace": "com.segment.TestApp" },
+      "app": { "namespace": "com.segment.TestApp", "version": 2 },
       "device": {
         "manufacturer": "some-brand",
         "type": "ios",
@@ -30,11 +30,13 @@
     "advertiser_tracking_enabled": 1,
     "application_tracking_enabled": 1,
     "bundle_id": "com.segment.TestApp",
+    "bundle_short_version": 2,
     "custom_events": [{
           "_eventName": "fb_mobile_level_achieved",
           "_logTime": 1447027200,
           "fb_currency": "USD",
-          "level": 10
+          "level": 10,
+          "_appVersion": 2
         }]
   }
 }

--- a/test/fixtures/track-custom-not-mapped.json
+++ b/test/fixtures/track-custom-not-mapped.json
@@ -33,7 +33,7 @@
     "advertiser_tracking_enabled": 1,
     "application_tracking_enabled": 1,
     "bundle_id": "com.segment.TestApp",
-    "bundle_short_version": 2.0,
+    "bundle_short_version": 2,
     "custom_events": [{
           "_eventName": "Clicked Something",
           "_logTime": 1447027200,

--- a/test/fixtures/track-custom-not-mapped.json
+++ b/test/fixtures/track-custom-not-mapped.json
@@ -1,13 +1,16 @@
 {
   "input": {
     "type": "track",
-    "event": "Password Changed",
+    "event": "Clicked Something",
     "userId": "user-id",
-    "properties": {},
+    "properties": { "level": 10 },
     "timestamp": "2015-11-09",
     "context": {
       "ip": "10.0.0.2",
-      "app": { "namespace": "com.segment.TestApp", "version": 2 },
+      "app": { 
+        "namespace": "com.segment.TestApp", 
+        "version": 2.0 
+      },
       "device": {
         "manufacturer": "some-brand",
         "type": "ios",
@@ -30,12 +33,13 @@
     "advertiser_tracking_enabled": 1,
     "application_tracking_enabled": 1,
     "bundle_id": "com.segment.TestApp",
-    "bundle_short_version": 2,
+    "bundle_short_version": 2.0,
     "custom_events": [{
-          "_eventName": "Password Changed",
+          "_eventName": "Clicked Something",
           "_logTime": 1447027200,
-          "_appVersion": 2,
-          "fb_currency": "USD"
-      }]
+          "_appVersion": 2.0,
+          "fb_currency": "USD",
+          "level": 10
+        }]
   }
 }

--- a/test/fixtures/track-custom-period.json
+++ b/test/fixtures/track-custom-period.json
@@ -10,7 +10,8 @@
     "context": {
       "ip": "10.0.0.2",
       "app": {
-        "namespace": "com.segment.TestApp"
+        "namespace": "com.segment.TestApp",
+        "version": 2 
       },
       "device": {
         "manufacturer": "some-brand",
@@ -36,12 +37,14 @@
     "advertiser_tracking_enabled": 1,
     "application_tracking_enabled": 1,
     "bundle_id": "com.segment.TestApp",
+    "bundle_short_version": 2,
     "custom_events": [
       {
         "_eventName": "Friend_Added",
         "_logTime": 1447027200,
         "fb_currency": "USD",
-        "level": 10
+        "level": 10,
+        "_appVersion": 2
       }
     ]
   }

--- a/test/fixtures/track-ecommerce-added-product.json
+++ b/test/fixtures/track-ecommerce-added-product.json
@@ -14,7 +14,7 @@
     },
     "context": {
       "ip": "10.0.0.2",
-      "app": { "namespace": "com.segment.TestApp" },
+      "app": { "namespace": "com.segment.TestApp", "version": 2 },
       "device": {
         "manufacturer": "some-brand",
         "type": "ios",
@@ -37,8 +37,10 @@
     "advertiser_tracking_enabled": 1,
     "application_tracking_enabled": 1,
     "bundle_id": "com.segment.TestApp",
+    "bundle_short_version": 2,
     "custom_events": [{
           "_eventName": "fb_mobile_add_to_cart",
+          "_appVersion": 2,
           "_logTime": 1447027200,
           "_valueToSum": 19,
           "fb_content_id": "507f1f77bcf86cd799439011",

--- a/test/fixtures/track-ecommerce-checkout-started.json
+++ b/test/fixtures/track-ecommerce-checkout-started.json
@@ -35,7 +35,7 @@
     },
     "context": {
       "ip": "10.0.0.2",
-      "app": { "namespace": "com.segment.TestApp" },
+      "app": { "namespace": "com.segment.TestApp", "version": 2 },
       "device": {
         "manufacturer": "some-brand",
         "type": "ios",
@@ -58,10 +58,12 @@
     "advertiser_tracking_enabled": 1,
     "application_tracking_enabled": 1,
     "bundle_id": "com.segment.TestApp",
+    "bundle_short_version": 2,
     "custom_events": [{
           "_eventName": "fb_mobile_initiated_checkout",
           "_valueToSum": 25,
           "_logTime": 1447027200,
+          "_appVersion": 2,
           "fb_currency": "USD",
           "fb_num_items": 3,
           "fb_content_id": ["507f1f77bcf86cd799439011", "505bd76785ebb509fc183733"],

--- a/test/fixtures/track-ecommerce-completed-order.json
+++ b/test/fixtures/track-ecommerce-completed-order.json
@@ -35,7 +35,7 @@
     },
     "context": {
       "ip": "10.0.0.2",
-      "app": { "namespace": "com.segment.TestApp" },
+      "app": { "namespace": "com.segment.TestApp", "version": 2 },
       "device": {
         "manufacturer": "some-brand",
         "type": "ios",
@@ -58,10 +58,12 @@
     "advertiser_tracking_enabled": 1,
     "application_tracking_enabled": 1,
     "bundle_id": "com.segment.TestApp",
+    "bundle_short_version": 2,
     "custom_events": [{
           "fb_currency": "USD",
           "_logTime": 1447027200,
           "_valueToSum": 25,
+          "_appVersion": 2,
           "_eventName": "fb_mobile_purchase",
           "fb_num_items": 3,
           "fb_content_id": ["507f1f77bcf86cd799439011", "505bd76785ebb509fc183733"],

--- a/test/fixtures/track-ecommerce-payment-info.json
+++ b/test/fixtures/track-ecommerce-payment-info.json
@@ -9,7 +9,8 @@
     },
     "context": {
       "ip": "10.0.0.2",
-      "app": { "namespace": "com.segment.TestApp" },
+      "app": { "namespace": "com.segment.TestApp",
+      "version": 2  },
       "device": {
         "manufacturer": "some-brand",
         "type": "ios",
@@ -32,9 +33,11 @@
     "advertiser_tracking_enabled": 1,
     "application_tracking_enabled": 1,
     "bundle_id": "com.segment.TestApp",
+    "bundle_short_version": 2,
     "custom_events": [{
           "_eventName": "fb_mobile_add_payment_info",
           "_logTime": 1447027200,
+          "_appVersion": 2,
           "payment_method": "Visa",
           "fb_currency": "USD"
         }]

--- a/test/fixtures/track-ecommerce-viewed-product.json
+++ b/test/fixtures/track-ecommerce-viewed-product.json
@@ -14,7 +14,7 @@
     },
     "context": {
       "ip": "10.0.0.2",
-      "app": { "namespace": "com.segment.TestApp" },
+      "app": { "namespace": "com.segment.TestApp", "version": 2  },
       "device": {
         "manufacturer": "some-brand",
         "type": "ios",
@@ -37,10 +37,12 @@
     "advertiser_tracking_enabled": 1,
     "application_tracking_enabled": 1,
     "bundle_id": "com.segment.TestApp",
+    "bundle_short_version": 2,
     "custom_events": [{
           "_logTime": 1447027200,
           "_valueToSum": 19,
           "_eventName": "fb_mobile_content_view",
+          "_appVersion": 2,
           "fb_content_id": "507f1f77bcf86cd799439011",
           "fb_description": "Monopoly: 3rd Edition",
           "fb_content_type": "Games",

--- a/test/fixtures/track-ecommerce-wishlisted-product.json
+++ b/test/fixtures/track-ecommerce-wishlisted-product.json
@@ -47,6 +47,7 @@
           "_eventName": "fb_mobile_add_to_wishlist",
           "fb_currency": "USD",
           "fb_num_items": 1,
+          "_appVersion": 2.0,
           "sku": "45790-32"
         }]
   }

--- a/test/fixtures/track-long-names.json
+++ b/test/fixtures/track-long-names.json
@@ -40,6 +40,7 @@
       {
         "_eventName": "Testing in case someone sends us events ",
         "_logTime": 1447027200,
+        "_appVersion": 2,
         "fb_currency": "USD"
       }
     ]

--- a/test/fixtures/track-search.json
+++ b/test/fixtures/track-search.json
@@ -7,7 +7,7 @@
     "timestamp": "2015-11-09",
     "context": {
       "ip": "10.0.0.2",
-      "app": { "namespace": "com.segment.TestApp" },
+      "app": { "namespace": "com.segment.TestApp", "version": 2  },
       "device": {
         "manufacturer": "some-brand",
         "type": "ios",
@@ -30,8 +30,10 @@
     "advertiser_tracking_enabled": 1,
     "application_tracking_enabled": 1,
     "bundle_id": "com.segment.TestApp",
+    "bundle_short_version": 2,
     "custom_events": [{
           "_eventName": "fb_mobile_search",
+          "_appVersion": 2,
           "fb_search_string": "r2d2",
           "_logTime": 1447027200,
           "fb_currency": "USD"

--- a/test/index.js
+++ b/test/index.js
@@ -82,6 +82,12 @@ describe('Facebook App Events', function(){
       });
     });
 
+    describe('custom unmapped track', function(){
+      it('should map custom unmapped event track', function(){
+        test.maps('track-custom-not-mapped');
+      });
+    });
+
     describe('custom track with a period in the name', function(){
       it('should map custom track with a period in the name', function(){
         test.maps('track-custom-period');


### PR DESCRIPTION
This PR fixes two bugs.

**Bug 1:** Custom events that were not mapped to any fb standard events in the segment UI were always being passed to FB as "event name: null".
**Cause:** null values from the settings object get stringified by Segment, which was causing eventName to pass a truthy test even when eventName was null.
**Fixed:** with commit https://github.com/segment-integrations/integration-facebook-app-events/commit/9ed6def8306ddebaddd49e3efbcc343a91591fde

**Bug 2:** All Custom events were being passed to FB with app version listed as "undefined".
**Cause:**  Facebook's custom_events parameter requires _appVersion as a field, otherwise "App Version" gets set to undefined in Facebook.
**Fixed:** with commit https://github.com/segment-integrations/integration-facebook-app-events/commit/91b45e38b9062d7330e46976853eab62e23f21b1
