### PR TITLE
add tests and logic

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -247,6 +247,12 @@ function customParams(msg, eventName){
   delete properties.products;
   extend(customEvents, properties);
 
+  // If message contains content_id or content_type in integrations.facebook object
+  // Then use the values that they explicitly include
+  var facebookOptions = msg.proxy('integrations.facebook') || {};
+  if (facebookOptions.content_id) customEvents.fb_content_id = facebookOptions.content_id;
+  if (facebookOptions.content_type) customEvents.fb_content_type = facebookOptions.content_type;
+
   if (!customEvents.fb_search_string) delete customEvents.fb_search_string;
   if (!customEvents.fb_content_id) delete customEvents.fb_content_id;
   if (!customEvents.fb_num_items) delete customEvents.fb_num_items;

--- a/test/fixtures/track-ecommerce-completed-order-options.json
+++ b/test/fixtures/track-ecommerce-completed-order-options.json
@@ -1,0 +1,87 @@
+{
+  "input": {
+    "type": "track",
+    "event": "Order Completed",
+    "userId": "user-id",
+    "timestamp": "2015-11-09",
+    "properties": {
+      "orderId": "50314b8e9bcf000000000000",
+      "total": 30,
+      "revenue": 25,
+      "shipping": 3,
+      "tax": 2,
+      "discount": 2.5,
+      "coupon": "hasbros",
+      "currency": "USD",
+      "repeat": true,
+      "products": [
+        {
+          "id": "507f1f77bcf86cd799439011",
+          "sku": "45790-32",
+          "name": "Monopoly: 3rd Edition",
+          "price": 19,
+          "quantity": 1,
+          "category": "Games"
+        },
+        {
+          "id": "505bd76785ebb509fc183733",
+          "sku": "46493-32",
+          "name": "Uno Card Game",
+          "price": 3,
+          "quantity": 2,
+          "category": "Games"
+        }
+      ]
+    },
+    "context": {
+      "ip": "10.0.0.2",
+      "app": { "namespace": "com.segment.TestApp", "version": 2 },
+      "device": {
+        "manufacturer": "some-brand",
+        "type": "ios",
+        "advertisingId": "159358",
+        "adTrackingEnabled": true
+      },
+      "network": { "carrier": "some-carrier" },
+      "locale": "en-US",
+      "library": {
+        "name": "analytics-ios"
+      },
+      "referrer": {
+        "type": "iad",
+        "id": "some-id"
+      }
+    },
+    "integrations": {
+      "Facebook": {
+        "content_type": "product",
+        "content_id": ["123", "234"]
+      }
+    }
+  },
+  "output": {
+    "event": "CUSTOM_APP_EVENTS",
+    "advertiser_id": "159358",
+    "advertiser_tracking_enabled": 1,
+    "application_tracking_enabled": 1,
+    "bundle_id": "com.segment.TestApp",
+    "bundle_short_version": 2,
+    "custom_events": [{
+          "fb_currency": "USD",
+          "_logTime": 1447027200,
+          "_valueToSum": 25,
+          "_appVersion": 2,
+          "_eventName": "fb_mobile_purchase",
+          "fb_num_items": 3,
+          "fb_content_id": ["123", "234"],
+          "fb_content_type": "product",
+          "coupon": "hasbros",
+          "total": 30,
+          "discount": 2.5,
+          "shipping": 3,
+          "tax": 2,
+          "orderId": "50314b8e9bcf000000000000",
+          "repeat": true
+        }]
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -152,6 +152,10 @@ describe('Facebook App Events', function(){
       it('should map Completed Order', function(){
         test.maps('track-ecommerce-completed-order');
       })
+
+      it('should map Completed Order with options', function(){
+        test.maps('track-ecommerce-completed-order-options');
+      })
     });
 
   });
@@ -259,6 +263,15 @@ describe('Facebook App Events', function(){
 
     it('should track Order Completed correctly', function(done){
       var json = test.fixture('track-ecommerce-completed-order');
+      test
+        .track(json.input)
+        .sends(json.output)
+        .expects(200)
+        .end(done);
+    });
+
+    it('should track Order Completed correctly with Facebook options', function(done){
+      var json = test.fixture('track-ecommerce-completed-order-options');
       test
         .track(json.input)
         .sends(json.output)


### PR DESCRIPTION
This change makes it possible to override the mapper and explicitly set your own facebook specific `fb_content_id` and `fb_content_type` values on payloads to facebook without having to send that data to other downstream tools.

@sperand-io @f2prateek 
