### PR TITLE
deprecate order started, use checkout started

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -190,8 +190,8 @@ FacebookAppEvents.prototype.paymentInfoAdded = function(track, callback) {
  * @param {Function} callback
  */
 
-FacebookAppEvents.prototype.orderStarted = function(track, callback) {
-  var payload = mapper.orderStarted(track, this.settings);
+FacebookAppEvents.prototype.checkoutStarted= function(track, callback) {
+  var payload = mapper.checkoutStarted(track, this.settings);
   return this
     .post('v2.6/' + this.settings.appId + '/activities')
     .send(payload)

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -164,7 +164,7 @@ exports.paymentInfoAdded = function(msg, settings){
  * @return {Object}
  */
 
-exports.orderStarted = function(msg, settings){
+exports.checkoutStarted = function(msg, settings){
   var eventName = "fb_mobile_initiated_checkout";
 
   return reject(extend(

--- a/test/fixtures/track-ecommerce-checkout-started.json
+++ b/test/fixtures/track-ecommerce-checkout-started.json
@@ -1,7 +1,7 @@
 {
   "input": {
     "type": "track",
-    "event": "Order Started",
+    "event": "Checkout Started",
     "userId": "user-id",
     "timestamp": "2015-11-09",
     "properties": {


### PR DESCRIPTION
This is coupled with https://github.com/segmentio/analytics-events/pull/7

No breaking impact since no customer is yet sending order started events

@f2prateek @jgershen 
