### PR TITLE
add support for spec v2

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -7,6 +7,7 @@ var reject = require('reject');
 var extend = require('extend');
 var foldl = require('@ndhoule/foldl');
 var time = require('unix-time');
+var Track = require('segmentio-facade').Track;
 
 /**
  * Map track.
@@ -231,6 +232,8 @@ function customParams(msg, eventName){
     currency: 'fb_currency',
     name: 'fb_description',
     id: 'fb_content_id',
+    product_id: 'fb_content_id',
+    productId: 'fb_content_id',
     category: 'fb_content_type'
   };
   var properties = msg.properties(renames);
@@ -293,10 +296,15 @@ function numberOfItems(msg) {
  */
 
 function contentIds(msg) {
-  var products = msg.proxy('properties.products');
-  if (products) {
-    return extractValue(products, 'id');
-  }
+  var products = msg.products();
+  var ret = [];
+  products.forEach(function(product) {
+    var item = new Track({ properties: product });
+    var id = item.productId() || item.id();
+    ret.push(id);
+  });
+
+  return ret.length > 0 ? ret : null;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "is": "^2.1.0",
     "qs": "^2.3.3",
     "reject": "0.0.1",
+    "segmentio-facade": "^3.1.0",
     "segmentio-integration": "^4.0.0",
     "unix-time": "^1.0.1"
   },

--- a/test/fixtures/track-ecommerce-added-product.json
+++ b/test/fixtures/track-ecommerce-added-product.json
@@ -5,7 +5,7 @@
     "userId": "user-id",
     "timestamp": "2015-11-09",
     "properties": {
-      "id": "507f1f77bcf86cd799439011",
+      "product_id": "507f1f77bcf86cd799439011",
       "sku": "45790-32",
       "name": "Monopoly: 3rd Edition",
       "price": 19,

--- a/test/fixtures/track-ecommerce-checkout-started.json
+++ b/test/fixtures/track-ecommerce-checkout-started.json
@@ -16,7 +16,7 @@
       "currency": "USD",
       "products": [
         {
-          "id": "507f1f77bcf86cd799439011",
+          "product_id": "507f1f77bcf86cd799439011",
           "sku": "45790-32",
           "name": "Monopoly: 3rd Edition",
           "price": 19,
@@ -24,7 +24,7 @@
           "category": "Games"
         },
         {
-          "id": "505bd76785ebb509fc183733",
+          "product_id": "505bd76785ebb509fc183733",
           "sku": "46493-32",
           "name": "Uno Card Game",
           "price": 3,

--- a/test/fixtures/track-ecommerce-completed-order.json
+++ b/test/fixtures/track-ecommerce-completed-order.json
@@ -5,7 +5,7 @@
     "userId": "user-id",
     "timestamp": "2015-11-09",
     "properties": {
-      "orderId": "50314b8e9bcf000000000000",
+      "order_id": "50314b8e9bcf000000000000",
       "total": 30,
       "revenue": 25,
       "shipping": 3,
@@ -16,7 +16,7 @@
       "repeat": true,
       "products": [
         {
-          "id": "507f1f77bcf86cd799439011",
+          "product_id": "507f1f77bcf86cd799439011",
           "sku": "45790-32",
           "name": "Monopoly: 3rd Edition",
           "price": 19,
@@ -24,7 +24,7 @@
           "category": "Games"
         },
         {
-          "id": "505bd76785ebb509fc183733",
+          "product_id": "505bd76785ebb509fc183733",
           "sku": "46493-32",
           "name": "Uno Card Game",
           "price": 3,
@@ -73,7 +73,7 @@
           "discount": 2.5,
           "shipping": 3,
           "tax": 2,
-          "orderId": "50314b8e9bcf000000000000",
+          "order_id": "50314b8e9bcf000000000000",
           "repeat": true
         }]
   }

--- a/test/fixtures/track-ecommerce-viewed-product.json
+++ b/test/fixtures/track-ecommerce-viewed-product.json
@@ -5,7 +5,7 @@
     "userId": "user-id",
     "timestamp": "2015-11-09",
     "properties": {
-      "id": "507f1f77bcf86cd799439011",
+      "product_id": "507f1f77bcf86cd799439011",
       "sku": "45790-32",
       "name": "Monopoly: 3rd Edition",
       "price": 19,


### PR DESCRIPTION
This PR supports object_id for ecom spec v2 in a nonbreaking way.

@f2prateek  
